### PR TITLE
add C bindings

### DIFF
--- a/bindings/c/tree-sitter-pkl.h
+++ b/bindings/c/tree-sitter-pkl.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_PKL_H
+#define TREE_SITTER_PKL_H
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const TSLanguage *tree_sitter_pkl();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PKL_H


### PR DESCRIPTION
This is needed if we want to compile tree-sitter-pkl to a native library using `kotlin-tree-sitter`.