### PR TITLE
Configure `hawkeye` to update license headers

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-amends ".../pkl-project-commons/packages/pkl.impl.circleci/PklCI.pkl"
+amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.2.0#/PklCI.pkl"
 
 prb = buildWorkflow
 
@@ -42,6 +42,19 @@ release {
 }
 
 jobs {
+  ["test-license-headers"] {
+    docker {
+      new {
+        image = "ghcr.io/korandoru/hawkeye"
+      }
+    }
+    steps {
+      "checkout"
+      new RunStep {
+        command = "/bin/hawkeye check --fail-if-unknown"
+      }
+    }
+  }
   ["build"] {
     docker {
       new {
@@ -96,6 +109,7 @@ jobs {
 
 local buildWorkflow = new Workflow {
   jobs {
+    "test-license-headers"
     "build"
   }
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,13 @@ version: '2.1'
 orbs:
   pr-approval: apple/pr-approval@0.1.0
 jobs:
+  test-license-headers:
+    steps:
+    - checkout
+    - run:
+        command: /bin/hawkeye check --fail-if-unknown
+    docker:
+    - image: ghcr.io/korandoru/hawkeye
   build:
     steps:
     - checkout
@@ -47,16 +54,19 @@ workflows:
         type: approval
     - pr-approval/authenticate:
         context: pkl-pr-approval
+    - test-license-headers:
+        requires:
+        - hold
     - build:
         requires:
         - hold
-        - pr-approval/authenticate
     when:
       matches:
         value: << pipeline.git.branch >>
         pattern: ^pull/\d+(/head)?$
   main:
     jobs:
+    - test-license-headers
     - build
     when:
       equal:

--- a/grammar.js
+++ b/grammar.js
@@ -1,11 +1,11 @@
-/**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+/*
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /// <reference path="node_modules/tree-sitter-cli/dsl.d.ts" />
 
 /**

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,0 +1,23 @@
+headerPath = "scripts/license-header.txt"
+
+includes = [
+    "*.c",
+    "*.cc",
+    "*.h",
+    "*.js",
+    "*.pkl",
+    "PklProject",
+]
+
+excludes = [
+    "bindings/*",
+    "parser.c",
+    "src/tree_sitter/*"
+]
+
+[git]
+attrs = 'auto'
+ignore = 'auto'
+
+[properties]
+copyrightOwner = "Apple Inc. and the Pkl project authors"

--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,0 +1,13 @@
+Copyright ©{{ " " }}{%- if attrs.git_file_modified_year != attrs.git_file_created_year -%}{{ attrs.git_file_created_year }}-{{ attrs.git_file_modified_year }}{%- else -%}{{ attrs.git_file_created_year }}{%- endif -%}{{ " " }}{{ props["copyrightOwner"] }}. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <tree_sitter/parser.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Adds configuration to format/check license headers with `hawkeye`.

Additionally, ran the formatter on license headers that needed to be updated.