### PR TITLE
Fix engine ranges in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": "^24.11.0",
-        "npm": "^11.6.1"
+        "node": ">= 24",
+        "npm": ">= 11"
       },
       "peerDependencies": {
         "tree-sitter": "^0.25.0"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/apple/tree-sitter-pkl/issues"
   },
   "engines": {
-    "node": "^24.11.0",
-    "npm": "^11.6.1"
+    "node": ">= 24",
+    "npm": ">= 11"
   },
   "dependencies": {
     "node-addon-api": "^8.5.0",


### PR DESCRIPTION
Change so that we allow engines newer than Node 24 and NPM 11.